### PR TITLE
mkdir before download the config file for openwrt-nikki

### DIFF
--- a/modules/openwrt-nikki/post-files.sh
+++ b/modules/openwrt-nikki/post-files.sh
@@ -9,4 +9,5 @@ echo "$feed" | cat - ./repositories.conf > temp && mv temp ./repositories.conf
 
 cp files/etc/opkg/keys/* keys
 
+mkdir -p files/etc/nikki/subscriptions
 wget --user-agent='clash' $CLASH_CONFIG_URL -O files/etc/nikki/subscriptions/default.yaml


### PR DESCRIPTION
Fix `imagebuilder  | files/etc/nikki/subscriptions/default.yaml: No such file or directory`