### PR TITLE
Add support for immortalwrt 24.10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,9 +27,15 @@ LOG "Default enabled modules: $default_modules"
 TARGET_VERSION="${TARGET_VERSION:-24.10}" # Default to 24.10 if not set
 IMAGEBUILDER_IMAGE="$IMAGEBUILDER_IMAGE"
 PACKAGES_FILE="./modules_in_container/base/packages" # Path inside container
+VERSION_REGEX="^[0-9]+\.[0-9]+(\.[0-9]+)?$" # Regex for major.minor or major.minor.patch
 
-# Extract the version number
-VERSION=$(echo "$IMAGEBUILDER_IMAGE" | awk -F ':' '{print $NF}')
+if [[ ! "$IMAGEBUILDER_IMAGE" =~ ":" ]] || ! [[ "$VERSION_TAG" =~ $VERSION_REGEX ]]; then
+    VERSION="23.05.4" # Default version if no colon or tag is not a version number
+    echo "Using default VERSION: $VERSION for IMAGEBUILDER_IMAGE: $IMAGEBUILDER_IMAGE"
+else
+    VERSION="$VERSION_TAG"
+    echo "Extracted VERSION: $VERSION from IMAGEBUILDER_IMAGE: $IMAGEBUILDER_IMAGE"
+fi
 
 # Function to compare versions (major.minor)
 is_version_greater_equal() {

--- a/run.sh
+++ b/run.sh
@@ -69,6 +69,9 @@ if [ -z "$MIRROR" ]; then
     MIRROR="mirrors.pku.edu.cn"
 fi
 
+# Set the TARGET_VERSION that need to change the modules
+TARGET_VERSION=24.10
+
 echo "IMAGEBUILDER_IMAGE: $IMAGEBUILDER_IMAGE PROFILE: $PROFILE"
 
 if [[ $IMAGEBUILDER_IMAGE =~ "immortalwrt" ]]; then
@@ -86,6 +89,8 @@ services:
       - PROFILE=$PROFILE
       - USE_MIRROR=$USE_MIRROR
       - MIRROR=$MIRROR
+      - TARGET_VERSION=$TARGET_VERSION
+      - IMAGEBUILDER_IMAGE=$IMAGEBUILDER_IMAGE
     env_file:
       - ./.env
     volumes:


### PR DESCRIPTION
Changed the script to modifiy the base/packages inside the build container if the user giving a imagebuilder version >=24.10.
might not working if the imagebuilder using a custom tag with no version number or tags like `latest`.